### PR TITLE
Add namespace to tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,12 @@
       "Aternos\\Codex\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Aternos\\Codex\\Test\\Src\\": "test/src/",
+      "Aternos\\Codex\\Test\\Tests\\": "test/tests/"
+    }
+  },
   "require-dev": {
     "phpunit/phpunit": "^9.5"
   },

--- a/test/src/Analysis/TestInformation.php
+++ b/test/src/Analysis/TestInformation.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Analysis;
+
 use Aternos\Codex\Analysis\Information;
 
 /**

--- a/test/src/Analysis/TestInsight.php
+++ b/test/src/Analysis/TestInsight.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Analysis;
+
 use Aternos\Codex\Analysis\Insight;
 
 /**

--- a/test/src/Analysis/TestPatternInformation.php
+++ b/test/src/Analysis/TestPatternInformation.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Analysis;
+
 use Aternos\Codex\Analysis\Information;
 use Aternos\Codex\Analysis\PatternInsightInterface;
 

--- a/test/src/Analysis/TestPatternProblem.php
+++ b/test/src/Analysis/TestPatternProblem.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Analysis;
+
 use Aternos\Codex\Analysis\PatternInsightInterface;
 use Aternos\Codex\Analysis\Problem;
 

--- a/test/src/Analysis/TestProblem.php
+++ b/test/src/Analysis/TestProblem.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Analysis;
+
 use Aternos\Codex\Analysis\Problem;
 
 /**

--- a/test/src/Analysis/TestSolution.php
+++ b/test/src/Analysis/TestSolution.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Analysis;
+
 use Aternos\Codex\Analysis\Solution;
 
 /**

--- a/test/src/Log/TestAlwaysDetectableLog.php
+++ b/test/src/Log/TestAlwaysDetectableLog.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Log;
+
 use Aternos\Codex\Detective\SinglePatternDetector;
 use Aternos\Codex\Log\DetectableLogInterface;
 use Aternos\Codex\Log\Log;

--- a/test/src/Log/TestLessDetectableLog.php
+++ b/test/src/Log/TestLessDetectableLog.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Log;
+
 use Aternos\Codex\Detective\LinePatternDetector;
 use Aternos\Codex\Log\DetectableLogInterface;
 use Aternos\Codex\Log\Log;

--- a/test/src/Log/TestMoreDetectableLog.php
+++ b/test/src/Log/TestMoreDetectableLog.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Log;
+
 use Aternos\Codex\Detective\LinePatternDetector;
 use Aternos\Codex\Log\DetectableLogInterface;
 use Aternos\Codex\Log\Log;

--- a/test/src/Log/TestNeverDetectableLog.php
+++ b/test/src/Log/TestNeverDetectableLog.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Log;
+
 use Aternos\Codex\Detective\SinglePatternDetector;
 use Aternos\Codex\Log\DetectableLogInterface;
 use Aternos\Codex\Log\Log;

--- a/test/src/Log/TestPatternLog.php
+++ b/test/src/Log/TestPatternLog.php
@@ -1,12 +1,13 @@
 <?php
 
-require_once __DIR__ . '/../../src/Analysis/TestPatternProblem.php';
-require_once __DIR__ . '/../../src/Analysis/TestPatternInformation.php';
+namespace Aternos\Codex\Test\Src\Log;
 
 use Aternos\Codex\Analyser\AnalyserInterface;
 use Aternos\Codex\Analyser\PatternAnalyser;
 use Aternos\Codex\Log\AnalysableLog;
 use Aternos\Codex\Parser\PatternParser;
+use Aternos\Codex\Test\Src\Analysis\TestPatternInformation;
+use Aternos\Codex\Test\Src\Analysis\TestPatternProblem;
 
 /**
  * Class TestLog

--- a/test/src/Printer/TestModification.php
+++ b/test/src/Printer/TestModification.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Src\Printer;
+
 use Aternos\Codex\Printer\Modification;
 
 /**

--- a/test/tests/Analyser/PatternAnalyserTest.php
+++ b/test/tests/Analyser/PatternAnalyserTest.php
@@ -1,13 +1,14 @@
 <?php
 
-require_once __DIR__ . '/../../src/Analysis/TestPatternProblem.php';
-require_once __DIR__ . '/../../src/Analysis/TestPatternInformation.php';
-require_once __DIR__ . '/../../src/Log/TestPatternLog.php';
+namespace Aternos\Codex\Test\Tests\Analyser;
 
 use Aternos\Codex\Analysis\Analysis;
 use Aternos\Codex\Log\Entry;
 use Aternos\Codex\Log\File\PathLogFile;
 use Aternos\Codex\Log\Line;
+use Aternos\Codex\Test\Src\Analysis\TestPatternInformation;
+use Aternos\Codex\Test\Src\Analysis\TestPatternProblem;
+use Aternos\Codex\Test\Src\Log\TestPatternLog;
 use PHPUnit\Framework\TestCase;
 
 class PatternAnalyserTest extends TestCase

--- a/test/tests/Analysis/AnalysisTest.php
+++ b/test/tests/Analysis/AnalysisTest.php
@@ -1,10 +1,11 @@
 <?php
 
-require_once __DIR__ . '/../../src/Analysis/TestInsight.php';
-require_once __DIR__ . '/../../src/Analysis/TestProblem.php';
-require_once __DIR__ . '/../../src/Analysis/TestInformation.php';
+namespace Aternos\Codex\Test\Tests\Analysis;
 
 use Aternos\Codex\Analysis\Analysis;
+use Aternos\Codex\Test\Src\Analysis\TestInformation;
+use Aternos\Codex\Test\Src\Analysis\TestInsight;
+use Aternos\Codex\Test\Src\Analysis\TestProblem;
 use PHPUnit\Framework\TestCase;
 
 class AnalysisTest extends TestCase

--- a/test/tests/Analysis/InformationTest.php
+++ b/test/tests/Analysis/InformationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-require_once __DIR__ . '/../../src/Analysis/TestInformation.php';
+namespace Aternos\Codex\Test\Tests\Analysis;
 
+use Aternos\Codex\Test\Src\Analysis\TestInformation;
 use PHPUnit\Framework\TestCase;
 
 class InformationTest extends TestCase
@@ -33,7 +34,7 @@ class InformationTest extends TestCase
     {
         $value = uniqid();
         $informationA = new TestInformation();
-        $informationA->setValue($value);;
+        $informationA->setValue($value);
         $informationB = new TestInformation();
         $informationB->setValue($value);
 

--- a/test/tests/Analysis/ProblemTest.php
+++ b/test/tests/Analysis/ProblemTest.php
@@ -1,8 +1,9 @@
 <?php
 
-require_once __DIR__ . '/../../src/Analysis/TestProblem.php';
-require_once __DIR__ . '/../../src/Analysis/TestSolution.php';
+namespace Aternos\Codex\Test\Tests\Analysis;
 
+use Aternos\Codex\Test\Src\Analysis\TestProblem;
+use Aternos\Codex\Test\Src\Analysis\TestSolution;
 use PHPUnit\Framework\TestCase;
 
 class ProblemTest extends TestCase

--- a/test/tests/Detector/DetectiveTest.php
+++ b/test/tests/Detector/DetectiveTest.php
@@ -1,12 +1,13 @@
 <?php
 
-require_once __DIR__ . '/../../src/Log/TestAlwaysDetectableLog.php';
-require_once __DIR__ . '/../../src/Log/TestLessDetectableLog.php';
-require_once __DIR__ . '/../../src/Log/TestMoreDetectableLog.php';
-require_once __DIR__ . '/../../src/Log/TestNeverDetectableLog.php';
+namespace Aternos\Codex\Test\Tests\Detector;
 
 use Aternos\Codex\Detective\Detective;
 use Aternos\Codex\Log\Log;
+use Aternos\Codex\Test\Src\Log\TestAlwaysDetectableLog;
+use Aternos\Codex\Test\Src\Log\TestLessDetectableLog;
+use Aternos\Codex\Test\Src\Log\TestMoreDetectableLog;
+use Aternos\Codex\Test\Src\Log\TestNeverDetectableLog;
 use PHPUnit\Framework\TestCase;
 
 class DetectiveTest extends TestCase

--- a/test/tests/Detector/LinePatternDetectorTest.php
+++ b/test/tests/Detector/LinePatternDetectorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Detector;
 
 use Aternos\Codex\Detective\LinePatternDetector;
 use PHPUnit\Framework\TestCase;

--- a/test/tests/Detector/SinglePatternDetectorTest.php
+++ b/test/tests/Detector/SinglePatternDetectorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Detector;
 
 use Aternos\Codex\Detective\SinglePatternDetector;
 use Aternos\Codex\Log\File\StringLogFile;

--- a/test/tests/Detector/WeightedSinglePatternDetectorTest.php
+++ b/test/tests/Detector/WeightedSinglePatternDetectorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Detector;
+
 use Aternos\Codex\Detective\WeightedSinglePatternDetector;
 use Aternos\Codex\Log\File\StringLogFile;
 use PHPUnit\Framework\TestCase;

--- a/test/tests/Log/EntryTest.php
+++ b/test/tests/Log/EntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Log;
+
 use Aternos\Codex\Log\Entry;
 use Aternos\Codex\Log\Line;
 use PHPUnit\Framework\TestCase;

--- a/test/tests/Log/File/PathLogFileTest.php
+++ b/test/tests/Log/File/PathLogFileTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Log\File;
 
 use Aternos\Codex\Log\File\PathLogFile;
 use PHPUnit\Framework\TestCase;

--- a/test/tests/Log/File/StreamLogFileTest.php
+++ b/test/tests/Log/File/StreamLogFileTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Log\File;
 
 use Aternos\Codex\Log\File\StreamLogFile;
 use PHPUnit\Framework\TestCase;

--- a/test/tests/Log/File/StringLogFileTest.php
+++ b/test/tests/Log/File/StringLogFileTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Log\File;
 
 use Aternos\Codex\Log\File\StringLogFile;
 use PHPUnit\Framework\TestCase;

--- a/test/tests/Log/LineTest.php
+++ b/test/tests/Log/LineTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Log;
+
 use Aternos\Codex\Log\Line;
 use PHPUnit\Framework\TestCase;
 

--- a/test/tests/Log/LogTest.php
+++ b/test/tests/Log/LogTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Log;
+
 use Aternos\Codex\Log\Entry;
 use Aternos\Codex\Log\Log;
 use PHPUnit\Framework\TestCase;

--- a/test/tests/Parser/DefaultParserTest.php
+++ b/test/tests/Parser/DefaultParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Parser;
+
 use Aternos\Codex\Log\Entry;
 use Aternos\Codex\Log\File\PathLogFile;
 use Aternos\Codex\Log\Line;

--- a/test/tests/Parser/PatternParserTest.php
+++ b/test/tests/Parser/PatternParserTest.php
@@ -1,11 +1,12 @@
 <?php
 
-require_once __DIR__ . '/../../src/Log/TestPatternLog.php';
+namespace Aternos\Codex\Test\Tests\Parser;
 
 use Aternos\Codex\Log\Entry;
 use Aternos\Codex\Log\File\PathLogFile;
 use Aternos\Codex\Log\Line;
 use Aternos\Codex\Log\Log;
+use Aternos\Codex\Test\Src\Log\TestPatternLog;
 use PHPUnit\Framework\TestCase;
 
 class PatternParserTest extends TestCase

--- a/test/tests/Printer/DefaultPrinterTest.php
+++ b/test/tests/Printer/DefaultPrinterTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Aternos\Codex\Test\Tests\Printer;
 
 use Aternos\Codex\Log\Entry;
 use Aternos\Codex\Log\File\PathLogFile;

--- a/test/tests/Printer/ModifiableDefaultPrinterTest.php
+++ b/test/tests/Printer/ModifiableDefaultPrinterTest.php
@@ -1,12 +1,13 @@
 <?php
 
-require_once __DIR__ . "/../../src/Printer/TestModification.php";
+namespace Aternos\Codex\Test\Tests\Printer;
 
 use Aternos\Codex\Log\Entry;
 use Aternos\Codex\Log\File\StringLogFile;
 use Aternos\Codex\Log\Line;
 use Aternos\Codex\Log\Log;
 use Aternos\Codex\Printer\ModifiableDefaultPrinter;
+use Aternos\Codex\Test\Src\Printer\TestModification;
 use PHPUnit\Framework\TestCase;
 
 class ModifiableDefaultPrinterTest extends TestCase

--- a/test/tests/Printer/PatternModificationTest.php
+++ b/test/tests/Printer/PatternModificationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . "/../../src/Printer/TestModification.php";
+namespace Aternos\Codex\Test\Tests\Printer;
 
 use Aternos\Codex\Log\File\StringLogFile;
 use Aternos\Codex\Log\Log;


### PR DESCRIPTION
This pr adds namespaces to the tests following the psr-4 namespace schema and suggesting to put
- all files in `test/src/` into the namespace `Aternos\Codex\Test\Src`
- all files in `test/tests/` into the namespace `Aternos\Codex\Test\Tests`
