### PR TITLE
Migrate file content checks to newer phpunit assertions

### DIFF
--- a/test/tests/Log/File/PathLogFileTest.php
+++ b/test/tests/Log/File/PathLogFileTest.php
@@ -12,6 +12,6 @@ class PathLogFileTest extends TestCase
         $path = __DIR__ . "/../../../data/simple.log";
         $logFile = new PathLogFile($path);
 
-        $this->assertEquals(file_get_contents($path), $logFile->getContent());
+        $this->assertStringEqualsFile($path, $logFile->getContent());
     }
 }

--- a/test/tests/Log/File/StreamLogFileTest.php
+++ b/test/tests/Log/File/StreamLogFileTest.php
@@ -13,6 +13,6 @@ class StreamLogFileTest extends TestCase
         $streamResource = fopen($path, 'r');
 
         $logFile = new StreamLogFile($streamResource);
-        $this->assertEquals(file_get_contents($path), $logFile->getContent());
+        $this->assertStringEqualsFile($path, $logFile->getContent());
     }
 }


### PR DESCRIPTION
Replace `$this->assertEquals(file_get_contents($path), ...)` with `$this->assertStringEqualsFile($path, ...)`.

See [phpunit documentation on assertStringEqualsFile](https://phpunit.readthedocs.io/en/9.5/assertions.html?highlight=assertStringEqualsFile#assertstringequalsfile).