### PR TITLE
Set return type of PatternInsightInterface->setMatches to void

### DIFF
--- a/src/Analysis/PatternInsightInterface.php
+++ b/src/Analysis/PatternInsightInterface.php
@@ -23,7 +23,7 @@ interface PatternInsightInterface extends InsightInterface
      *
      * @param array $matches
      * @param $patternKey
-     * @return mixed
+     * @return void
      */
-    public function setMatches(array $matches, $patternKey);
+    public function setMatches(array $matches, $patternKey): void;
 }

--- a/test/src/Analysis/TestPatternInformation.php
+++ b/test/src/Analysis/TestPatternInformation.php
@@ -29,9 +29,9 @@ class TestPatternInformation extends Information implements PatternInsightInterf
      *
      * @param array $matches
      * @param $patternKey
-     * @return mixed
+     * @return void
      */
-    public function setMatches(array $matches, $patternKey)
+    public function setMatches(array $matches, $patternKey): void
     {
         $this->value = $matches[1];
     }

--- a/test/src/Analysis/TestPatternProblem.php
+++ b/test/src/Analysis/TestPatternProblem.php
@@ -42,9 +42,9 @@ class TestPatternProblem extends Problem implements PatternInsightInterface
      *
      * @param array $matches
      * @param $patternKey
-     * @return mixed
+     * @return void
      */
-    public function setMatches(array $matches, $patternKey)
+    public function setMatches(array $matches, $patternKey): void
     {
         $this->cause = $matches[1];
     }


### PR DESCRIPTION
`public function setMatches(array $matches, $patternKey)` doesn't return anything and isn't meant to return anything. It's just a setter. So I would like to set the return type hint of it to void.
Since it's type hinted this might break compatibility.
