### PR TITLE
Add constructor to PatternModification

### DIFF
--- a/src/Printer/PatternModification.php
+++ b/src/Printer/PatternModification.php
@@ -12,12 +12,22 @@ class PatternModification extends Modification
     /**
      * @var string
      */
-    protected $pattern;
+    protected string $pattern;
 
     /**
      * @var string
      */
-    protected $replacement;
+    protected string $replacement;
+
+    /**
+     * @param string $pattern
+     * @param string $replacement
+     */
+    public function __construct(string $pattern, string $replacement)
+    {
+        $this->pattern = $pattern;
+        $this->replacement = $replacement;
+    }
 
     /**
      * Set the pattern
@@ -27,7 +37,7 @@ class PatternModification extends Modification
      * @param string $pattern
      * @return $this
      */
-    public function setPattern(string $pattern)
+    public function setPattern(string $pattern): PatternModification
     {
         $this->pattern = $pattern;
         return $this;
@@ -41,7 +51,7 @@ class PatternModification extends Modification
      * @param string $replacement
      * @return $this
      */
-    public function setReplacement(string $replacement)
+    public function setReplacement(string $replacement): PatternModification
     {
         $this->replacement = $replacement;
         return $this;

--- a/test/tests/Printer/PatternModificationTest.php
+++ b/test/tests/Printer/PatternModificationTest.php
@@ -18,7 +18,7 @@ class PatternModificationTest extends TestCase
         $log->parse();
 
         $printer = new ModifiableDefaultPrinter();
-        $printer->addModification((new PatternModification())->setPattern('/foo/')->setReplacement('bar'));
+        $printer->addModification(new PatternModification('/foo/', 'bar'));
         $printer->setLog($log);
         $this->assertEquals("This is bar!", trim($printer->print()));
     }


### PR DESCRIPTION
I'd like to add a constructor with the two properties `string $pattern` and `string $replacement` to PatternModification for two reasons:

1. A PatternModification is useless without a Pattern and a Replacement. There is no use case for a PatternModification that has only one or none of the two properties set.
2. It is easier to deal with typed properties if we can be sure that both properties are set.